### PR TITLE
From postfix-grok-patterns

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -12,7 +12,7 @@ require 'yaml'
 # It creates test cases from all yaml files in the current
 # directory.
 
-class TestGrokPatterns < MiniTest::Test
+class TestGrokPatterns < Minitest::Test
 
     @@test_dir = File.dirname(__FILE__)
     @@upstream_pattern_dir = @@test_dir + '/logstash-patterns-core/patterns'


### PR DESCRIPTION
> Minitest no longer uses the `MiniTest` with capital `T` since forever.